### PR TITLE
Improved nav accesability

### DIFF
--- a/src/components/nav/nav.jsx
+++ b/src/components/nav/nav.jsx
@@ -1,7 +1,7 @@
 import "./navstyle.css";
 import Navbutton from "../navbutton/navbutton";
 import Hambutton from "../hambutton/hambutton";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useAtom } from "jotai";
 import { modalAtom } from "../../jotai/atoms";
 
@@ -9,9 +9,15 @@ const Nav=()=> {
     const [, toggleModal]=useAtom(modalAtom);
     const[smallNavVis,newsmalldis]=useState(false);
 
-    const showModal=()=>{
-        toggleModal(true)
-    }
+    useEffect(()=>{
+        if(window.innerWidth < 800 && !smallNavVis){
+            setTimeout(()=>{
+                document.querySelector("nav").style.display="none"
+            },200)
+        }
+    },[smallNavVis])
+
+    const showModal=()=> toggleModal(true)
 
     const hamClicked=()=>{
         document.querySelector("nav").style.display="block"
@@ -20,12 +26,7 @@ const Nav=()=> {
         },0)
     }
 
-    const hideNav=()=>{
-        newsmalldis(false)
-        setTimeout(()=>{
-            document.querySelector("nav").style.display="none"
-        },200)
-    }
+    const hideNav=()=> newsmalldis(false)
     
     const buttonValues = ["About", "Front-End", "Back-End", "Education"]
     return(


### PR DESCRIPTION
When your page is less than 800px wide and hitting the tab key, you can focus the hidden nav items. This updated version will make the hidden nav items unfocusable even right after the page load